### PR TITLE
fix to use it on a WAMP-System

### DIFF
--- a/pc-ide-helper.php
+++ b/pc-ide-helper.php
@@ -61,7 +61,7 @@ function _processMetadata($sPath)
 $modulePath = dirname(__FILE__) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'modules';
 $dir = new RecursiveDirectoryIterator($modulePath);
 $iter = new RecursiveIteratorIterator($dir);
-$files = new RegexIterator($iter, '/\/metadata\.php$/i', RecursiveRegexIterator::GET_MATCH);
+$files = new RegexIterator($iter, '/metadata\.php$/i', RecursiveRegexIterator::GET_MATCH);
 
 $str = "<?php\n/*\n" . date('Y-m-d H:i:s') . " - auto-generated file, do not edit! \nhttps://github.com/proudcommerce/oxid-ide-modulehelper\n*/\n";
 foreach ($files as $name => $file) {


### PR DESCRIPTION
Hi Tobi,

a small fix, to use your tool on a WAMP-System.

And a question?

Is it possible for you to provide an composer.json?

In the moment, I provide your composer-stuff by myself in my root composer.json:

```
...
    "repositories": [
        {
            "type": "package",
            "package": {
                "name": "proudcommerce/oxid-ide-modulehelper",
                "version": "master",
                "source": {
                    "url": "https://github.com/proudcommerce/oxid-ide-modulehelper",
                    "type": "git",
                    "reference": "master"
                }
            }
        }
    ],
    "require-dev": {
...
        "proudcommerce/oxid-ide-modulehelper": "*@dev"
    },
...
```
And i run before the first start: 
`copy vendor/proudcommerce/oxid-ide-modulehelper/pc-ide-helper.php source/bin/`

Later then 
`php source\bin\pc-ide-helper.php`